### PR TITLE
Make the memory soft cap configurable and make `Settings` non-exhaustive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "parity-ws"
 readme = "README.md"
 repository = "https://github.com/paritytech/ws-rs"
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies]
 byteorder = "1.2.1"

--- a/examples/bench-server.rs
+++ b/examples/bench-server.rs
@@ -4,11 +4,11 @@ extern crate parity_ws as ws;
 use ws::{Builder, Sender, Settings};
 
 fn main() {
+    let mut settings = Settings::default();
+    settings.max_connections = 10_000;
+
     Builder::new()
-        .with_settings(Settings {
-            max_connections: 10_000,
-            ..Settings::default()
-        })
+        .with_settings(settings)
         .build(|out: Sender| move |msg| out.send(msg))
         .unwrap()
         .listen("127.0.0.1:3012")

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -54,11 +54,11 @@ fn main() {
         }
     }
 
+    let mut settings = Settings::default();
+    settings.max_connections = CONNECTIONS;
+
     let mut ws = Builder::new()
-        .with_settings(Settings {
-            max_connections: CONNECTIONS,
-            ..Settings::default()
-        })
+        .with_settings(settings)
         .build(|out| Connection {
             out,
             count: 0,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -974,9 +974,7 @@ where
             }
         }
 
-        if self.in_buffer.is_empty() {
-            self.in_buffer.apply_soft_limit(self.settings.in_buffer_capacity_soft_limit);
-        }
+        self.in_buffer.apply_soft_limit(self.settings.in_buffer_capacity_soft_limit);
         Ok(())
     }
 
@@ -997,9 +995,7 @@ where
 
                 if let Some(len) = self.socket.try_write_buf(&mut self.out_buffer)? {
                     trace!("Wrote {} bytes to {}", len, self.peer_addr());
-                    if self.out_buffer.is_empty() {
-                        self.out_buffer.apply_soft_limit(self.settings.out_buffer_capacity_soft_limit);
-                    }
+                    self.out_buffer.apply_soft_limit(self.settings.out_buffer_capacity_soft_limit);
 
                     let finished = len == 0 || self.out_buffer.is_empty();
                     if finished {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ where
 }
 
 /// WebSocket settings
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy)]
 pub struct Settings {
     /// The maximum number of connections that this WebSocket will support.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,13 @@ pub struct Settings {
     /// The maximum size to which the incoming buffer can grow. This is a hard limit, and anything
     /// written to the buffer over this limit will result in an error.
     /// Default: 10,485,760
-    pub max_in_buffer_capacity: usize,
+    pub in_buffer_capacity_hard_limit: usize,
+    /// The maximum size to which the incoming buffer should grow. This is a soft limit, so it is
+    /// possible for the buffer to grow over this limit, however once its capacity grows beyond
+    /// this value it will be freed as soon as the buffer is emptied out, and reallocated with
+    /// its initial capacity once it's needed again.
+    /// Default: 1,048,576
+    pub in_buffer_capacity_soft_limit: usize,
     /// The initial size of the outgoing buffer. A larger buffer uses more memory but will allow for
     /// fewer reallocations.
     /// Default: 2048
@@ -177,7 +183,13 @@ pub struct Settings {
     /// The maximum size to which the outgoing buffer can grow. This is a hard limit, and anything
     /// written to the buffer over this limit will result in an error.
     /// Default: 10,485,760
-    pub max_out_buffer_capacity: usize,
+    pub out_buffer_capacity_hard_limit: usize,
+    /// The maximum size to which the outgoing buffer should grow. This is a soft limit, so it is
+    /// possible for the buffer to grow over this limit, however once its capacity grows beyond
+    /// this value it will be freed as soon as the buffer is emptied out, and reallocated with
+    /// its initial capacity once it's needed again.
+    /// Default: 1,048,576
+    pub out_buffer_capacity_soft_limit: usize,
     /// Whether to panic when an Internal error is encountered. Internal errors should generally
     /// not occur, so this setting defaults to true as a debug measure, whereas production
     /// applications should consider setting it to false.
@@ -251,9 +263,11 @@ impl Default for Settings {
             fragment_size: u16::max_value() as usize,
             max_fragment_size: usize::max_value(),
             in_buffer_capacity: 2048,
-            max_in_buffer_capacity: 10 * 1024 * 1024,
+            in_buffer_capacity_hard_limit: 10 * 1024 * 1024,
+            in_buffer_capacity_soft_limit: 1024 * 1024,
             out_buffer_capacity: 2048,
-            max_out_buffer_capacity: 10 * 1024 * 1024,
+            out_buffer_capacity_hard_limit: 10 * 1024 * 1024,
+            out_buffer_capacity_soft_limit: 1024 * 1024,
             panic_on_internal: true,
             panic_on_capacity: false,
             panic_on_protocol: false,


### PR DESCRIPTION
This is the continuation of https://github.com/paritytech/ws-rs/pull/6